### PR TITLE
Use dependency injection by string array

### DIFF
--- a/src/ionic.contrib.drawer.vertical.js
+++ b/src/ionic.contrib.drawer.vertical.js
@@ -4,7 +4,9 @@
 
 	angular.module('ionic.contrib.drawer.vertical', ['ionic'])
 
-	.controller('$ionDrawerVertical', function($scope, $element, $attrs, $ionicGesture, $timeout, $q, $ionicHistory, $ionDrawerVerticalDelegate, $ionicScrollDelegate, $interpolate) {
+	.controller('$ionDrawerVertical', [
+		'$scope', '$element', '$attrs', '$ionicGesture', '$timeout', '$q', '$ionicHistory', '$ionDrawerVerticalDelegate', '$ionicScrollDelegate', '$interpolate',
+		function($scope, $element, $attrs, $ionicGesture, $timeout, $q, $ionicHistory, $ionDrawerVerticalDelegate, $ionicScrollDelegate, $interpolate) {
 
 		// We need closure
 		var self = this;
@@ -343,7 +345,7 @@
 
 		}
 
-	});
+	}]);
 
 })();
 


### PR DESCRIPTION
This PR fixes an issue encountered when minifying js code, because of dependency variables being renamed. I've updated injection by using string array declaration instead #20 